### PR TITLE
tx 서명 & db 저장 태스크화

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,9 +1,13 @@
+import datetime
 import json
 import time
 import unittest
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import pytest
+from pytest_httpx import HTTPXMock
+from slack_sdk.web import SlackResponse
 
 from world_boss.app.cache import set_to_cache, cache_exists
 
@@ -55,3 +59,70 @@ def test_generate_ranking_rewards_csv(fx_test_client):
         assert req.status_code == 200
         assert req.json == 200
         m.assert_called_once_with("channel_id", 1, 2, 3)
+
+
+@pytest.mark.parametrize("has_header", [True, False])
+def test_prepare_transfer_assets(fx_test_client, has_header: bool):
+    content = (
+        "raid_id,ranking,agent_address,avatar_address,amount,ticker,decimal_places,target_nonce\n2,1,"
+        "0xC36f031aA721f52532BA665Ba9F020e45437D98D,5Ea5755eD86631a4D086CC4Fae41740C8985F1B4,1000000,CRYSTAL,"
+        "18,55\n2,1,0xC36f031aA721f52532BA665Ba9F020e45437D98D,5Ea5755eD86631a4D086CC4Fae41740C8985F1B4,3500,"
+        "RUNESTONE_FENRIR1,0,55\n2,1,0xC36f031aA721f52532BA665Ba9F020e45437D98D,"
+        "5Ea5755eD86631a4D086CC4Fae41740C8985F1B4,1200,RUNESTONE_FENRIR2,0,55\n2,1,"
+        "0xC36f031aA721f52532BA665Ba9F020e45437D98D,5Ea5755eD86631a4D086CC4Fae41740C8985F1B4,300,"
+        "RUNESTONE_FENRIR3,0,55 "
+    )
+    mocked_response = MagicMock()
+    mocked_response.data = {
+        "content": content,
+    }
+    recipient_map = {
+        55: [
+            {
+                "amount": {
+                    "decimalPlaces": 18,
+                    "quantity": 1000000,
+                    "ticker": "CRYSTAL",
+                },
+                "recipient": "0xC36f031aA721f52532BA665Ba9F020e45437D98D",
+            },
+            {
+                "amount": {
+                    "decimalPlaces": 0,
+                    "quantity": 3500,
+                    "ticker": "RUNESTONE_FENRIR1",
+                },
+                "recipient": "5Ea5755eD86631a4D086CC4Fae41740C8985F1B4",
+            },
+            {
+                "amount": {
+                    "decimalPlaces": 0,
+                    "quantity": 1200,
+                    "ticker": "RUNESTONE_FENRIR2",
+                },
+                "recipient": "5Ea5755eD86631a4D086CC4Fae41740C8985F1B4",
+            },
+            {
+                "amount": {
+                    "decimalPlaces": 0,
+                    "quantity": 300,
+                    "ticker": "RUNESTONE_FENRIR3",
+                },
+                "recipient": "5Ea5755eD86631a4D086CC4Fae41740C8985F1B4",
+            },
+        ]
+    }
+    with unittest.mock.patch(
+        "world_boss.app.api.client.files_info", return_value=mocked_response
+    ) as m, unittest.mock.patch("world_boss.app.api.sign_transfer_assets.delay") as m2:
+        req = fx_test_client.post(
+            f"/raid/prepare",
+            data={
+                "text": "https://planetariumhq.slack.com/files/1/2/test.csv 2022-12-31",
+                "channel_id": "channel_id",
+            },
+        )
+        assert req.status_code == 200
+        assert req.json == 200
+        m.assert_called_once_with(file="2")
+        m2.assert_called_once_with(recipient_map, "2022-12-31")

--- a/tests/kms_test.py
+++ b/tests/kms_test.py
@@ -7,18 +7,23 @@ from pytest_httpx import HTTPXMock
 from world_boss.app.enums import NetworkType
 from world_boss.app.kms import signer, HEADLESS_URLS, MINER_URLS
 from world_boss.app.models import Transaction
+from world_boss.app.stubs import Recipient
 
 
 def test_address():
     assert signer.address == "0x2531e5e06cBD11aF54f98D39578990716fFC7dBa"
 
 
-def test_transfer_assets(fx_session):
+def test_transfer_assets(fx_session) -> None:
     time_stamp = datetime.datetime(2022, 12, 31, tzinfo=datetime.timezone.utc)
     nonce = 2
-    recipient = {
+    recipient: Recipient = {
         "recipient": signer.address,
-        "amount": {"quantity": 10, "decimalPlaces": 18, "ticker": "CRYSTAL"},
+        "amount": {
+            "quantity": 10,
+            "decimalPlaces": 18,
+            "ticker": "CRYSTAL",
+        },
     }
     result = signer.transfer_assets(
         time_stamp,

--- a/world_boss/app/api.py
+++ b/world_boss/app/api.py
@@ -1,6 +1,13 @@
-from flask import Blueprint, request, jsonify
-from world_boss.app.raid import get_raid_rewards
-from world_boss.app.tasks import count_users, get_ranking_rewards
+import csv
+import datetime
+from io import StringIO
+from typing import cast
+
+from flask import Blueprint, request, jsonify, Response
+from world_boss.app.raid import get_raid_rewards, row_to_recipient
+from world_boss.app.slack import client
+from world_boss.app.stubs import Recipient
+from world_boss.app.tasks import count_users, get_ranking_rewards, sign_transfer_assets
 
 api = Blueprint("api", __name__)
 
@@ -29,4 +36,33 @@ def generate_ranking_rewards_csv():
     raid_id, total_users, nonce = [int(v) for v in values]
     channel_id = request.values.get("channel_id")
     get_ranking_rewards.delay(channel_id, raid_id, total_users, nonce)
+    return jsonify(200)
+
+
+@api.post("/raid/prepare")
+def prepare_transfer_assets() -> Response:
+    link, time_stamp = request.values.get("text", "").split()
+    file_id = link.split("/")[5]
+    res = client.files_info(file=file_id)
+    data = cast(dict, res.data)
+    content = data["content"]
+    stream = StringIO(content)
+    has_header = csv.Sniffer().has_header(content)
+    reader = csv.reader(stream)
+    if has_header:
+        next(reader, None)
+    recipient_map: dict[int, list[Recipient]] = {}
+    start_ranking: int
+    last_ranking: int
+    # raid_id,ranking,agent_address,avatar_address,amount,ticker,decimal_places,target_nonce
+    for row in reader:
+        nonce = int(row[7])
+        recipient = row_to_recipient(row)
+        # first row by each nonce
+        if not recipient_map.get(nonce):
+            recipient_map[nonce] = []
+        recipient_map[nonce].append(recipient)
+    for k in recipient_map:
+        assert len(recipient_map[k]) <= 100
+    sign_transfer_assets.delay(recipient_map, time_stamp)
     return jsonify(200)

--- a/world_boss/app/kms.py
+++ b/world_boss/app/kms.py
@@ -19,7 +19,7 @@ from world_boss.app.config import config
 from world_boss.app.enums import NetworkType
 from world_boss.app.models import Transaction
 from world_boss.app.orm import db
-
+from world_boss.app.stubs import Recipient
 
 MINER_URLS: dict[NetworkType, str] = {
     NetworkType.MAIN: "http://9c-main-miner-3.nine-chronicles.com/graphql",
@@ -130,7 +130,7 @@ class KmsWorldBossSigner:
         self,
         time_stamp: datetime.datetime,
         nonce: int,
-        recipients: typing.List[typing.Dict],
+        recipients: typing.List[Recipient],
         memo: str,
         headless_url: str,
     ) -> Transaction:

--- a/world_boss/app/raid.py
+++ b/world_boss/app/raid.py
@@ -15,6 +15,8 @@ from world_boss.app.stubs import (
     RaiderWithAgentDictionary,
     RewardDictionary,
     CurrencyDictionary,
+    Recipient,
+    RecipientRow,
 )
 
 
@@ -137,3 +139,20 @@ def write_ranking_rewards_csv(
                     ]
                 )
                 i += 1
+
+
+def row_to_recipient(row: RecipientRow) -> Recipient:
+    agent_address = row[2]
+    avatar_address = row[3]
+    amount = int(row[4])
+    ticker = row[5]
+    decimal_places = int(row[6])
+    recipient = agent_address if ticker == "CRYSTAL" else avatar_address
+    return {
+        "recipient": recipient,
+        "amount": {
+            "quantity": amount,
+            "decimalPlaces": decimal_places,
+            "ticker": ticker,
+        },
+    }

--- a/world_boss/app/stubs.py
+++ b/world_boss/app/stubs.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, List, Dict
+from typing import Optional, List, Annotated
 
 from mypy_extensions import TypedDict
 
@@ -21,3 +21,13 @@ RankingRewardWithAgentDictionary = TypedDict(
     "RankingRewardWithAgentDictionary",
     {"raider": RaiderWithAgentDictionary, "rewards": List[RewardDictionary]},
 )
+RecipientRow = Annotated[List[str], 8]
+AmountDictionary = TypedDict(
+    "AmountDictionary",
+    {
+        "ticker": str,
+        "decimalPlaces": int,
+        "quantity": int,
+    },
+)
+Recipient = TypedDict("Recipient", {"recipient": str, "amount": AmountDictionary})


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3193043/207838844-d410c960-e290-4c34-a629-c89ea41a09e0.png)

- #10 을 실행해서 얻은 csv파일을 활용해서 tx 서명 및 db 저장을 자동화합니다. (업로드할 파일은 슬랙에서 설정이 가능합니다.)
- kms signer에 async method로 구현해놓은 서명관련 기능을 셀러리 태스크에서 실행가능하도록 async를 제거합니다.
