### PR TITLE
보상 정산용 PrepareRewardAssets 액션 추출 자동화

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -162,8 +162,29 @@ def test_next_tx_nonce(
         m.assert_called_once_with(channel="channel_id", text="next tx nonce: 2")
 
 
+def test_prepare_reward_assets(fx_test_client):
+    with unittest.mock.patch(
+        "world_boss.app.api.upload_prepare_reward_assets.delay"
+    ) as m, unittest.mock.patch(
+        "world_boss.app.slack.verifier.is_valid_request", return_value=True
+    ):
+        req = fx_test_client.post(
+            "/prepare-reward-assets", data={"channel_id": "channel_id", "text": "3"}
+        )
+        assert req.status_code == 200
+        assert req.json == 200
+        m.assert_called_once_with("channel_id", 3)
+
+
 @pytest.mark.parametrize(
-    "url", ["/raid/list/count", "/raid/rewards/list", "/raid/prepare", "/nonce"]
+    "url",
+    [
+        "/raid/list/count",
+        "/raid/rewards/list",
+        "/raid/prepare",
+        "/nonce",
+        "/prepare-reward-assets",
+    ],
 )
 def test_slack_auth(fx_test_client, url: str):
     req = fx_test_client.post(url)

--- a/world_boss/app/api.py
+++ b/world_boss/app/api.py
@@ -10,6 +10,7 @@ from world_boss.app.tasks import (
     count_users,
     get_ranking_rewards,
     prepare_world_boss_ranking_rewards,
+    upload_prepare_reward_assets,
 )
 
 api = Blueprint("api", __name__)
@@ -70,4 +71,13 @@ def next_tx_nonce():
         channel=channel_id,
         text=f"next tx nonce: {nonce}",
     )
+    return jsonify(200)
+
+
+@api.post("/prepare-reward-assets")
+@slack_auth
+def prepare_reward_assets():
+    channel_id = request.values.get("channel_id")
+    raid_id = request.values.get("text", type=int)
+    upload_prepare_reward_assets.delay(channel_id, raid_id)
     return jsonify(200)


### PR DESCRIPTION
월드보스 보상 정산시 재화충전에 사용되는 액션의 준비를 db에 저장된 정보를 기준으로 자동으로 추출해주는 명령어를 추가합니다.

![image](https://user-images.githubusercontent.com/3193043/209285075-03e973a2-783c-400e-9196-f86f2711f8d7.png)

![image](https://user-images.githubusercontent.com/3193043/209285097-7e6051cf-1f97-47a4-9287-98f9bfcaaecf.png)
